### PR TITLE
GH Actions: add actionlint job

### DIFF
--- a/.github/workflows/reusable-yamllint.yml
+++ b/.github/workflows/reusable-yamllint.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       strict:
-        description: 'Whether to enable strict mode.'
+        description: 'Whether to enable strict mode for yamllint.'
         type: boolean
         required: false
         default: false
@@ -31,3 +31,23 @@ jobs:
       - name: Pipe Yamllint results on to GH for inline display
         if: ${{ failure() && github.event_name == 'pull_request' }}
         run: yamllint . --format github ${{ inputs.strict && '--strict' || '' }}
+
+  actionlint:
+    name: 'Check GHA workflows'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Add problem matcher
+        if: ${{ github.event_name == 'pull_request' }}
+        shell: bash
+        run: |
+          curl -o actionlint-matcher.json https://raw.githubusercontent.com/rhysd/actionlint/main/.github/actionlint-matcher.json
+          echo "::add-matcher::actionlint-matcher.json"
+
+      - name: Check workflow files
+        uses: docker://rhysd/actionlint:latest
+        with:
+          args: -color


### PR DESCRIPTION
Add a separate job to the `reusable-yamllint` workflow to validate the (reusable) workflows against common errors and potential problems and show the results inline in pull requests.

In particular, this is intended to protect against errors being introduced in the reusable workflows, as not all of those are run from within this repo, so errors would only be discovered via a failing build in _another_ repo, which does run the reusable workflow. This new job is intended to prevent this potential issue.

As this is a reusable workflow, other repos using this workflow will automatically inherit this job. While this may not be _strictly_ necessary (as for other repos, the workflows will generally always be run), it also doesn't do any harm to have that extra verification in place.

Loosely based on wp-cli/.github#111

Refs:
* https://github.com/rhysd/actionlinthttps://github.com/rhysd/actionlint
* https://github.com/rhysd/actionlint/blob/main/docs/README.md