### PR TITLE
GH Actions/reusable-phpstan.yml: add "version" configurable option

### DIFF
--- a/.github/workflows/reusable-phpstan.yml
+++ b/.github/workflows/reusable-phpstan.yml
@@ -2,6 +2,12 @@ name: PHPStan
 
 on:
   workflow_call:
+    inputs:
+      version:
+        description: "The PHPStan version to use. Defaults to the latest available version."
+        type: string
+        required: false
+        default: ""
 
 jobs:
   phpstan:
@@ -18,13 +24,22 @@ jobs:
         with:
           files: "phpstan.neon*"
 
+      - name: Create tools string
+        id: tools
+        run: |
+          if [ "${{ inputs.version }}" == "" ]; then
+            echo 'TOOLS=phpstan' >> "$GITHUB_OUTPUT"
+          else
+            echo 'TOOLS=phpstan:${{ inputs.version }}' >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Install PHP
         if: ${{ steps.has_config.outputs.files_exists == 'true' }}
         uses: shivammathur/setup-php@v2
         with:
           php-version: 'latest'
           coverage: none
-          tools: phpstan
+          tools: ${{ steps.tools.outputs.TOOLS }}
 
       # Install dependencies and handle caching in one go.
       # Dependencies need to be installed to make sure the PHPUnit classes are recognized.


### PR DESCRIPTION
This Monday, [PHPStan 2.0 will be released](https://phpc.social/@OndrejMirtes/113441109253809720).

To allow for packages which use this reusable workflow to choose whether to stay on PHPStan 1.x or to (automatically) move to PHPStan 2.x, this commit adds a new, optional `version` input option for the reusable PHPStan workflow.

* When not set, the workflow will instruct setup-php to install the latest available PHPStan version (same as before).
* When set, the workflow will instruct setup-php to install whatever version was given.

The version number provided by the calling workflow should comply with the supposed ways of providing a version nr as per setup-php: https://github.com/shivammathur/setup-php/?tab=readme-ov-file#wrench-tools-support