### PR TITLE
GH Actions/reusable-remark workflow: update config

### DIFF
--- a/.github/workflows/reusable-remark.yml
+++ b/.github/workflows/reusable-remark.yml
@@ -77,7 +77,7 @@ jobs:
         if: ${{ failure() && github.event_name == 'pull_request' }}
         uses: reviewdog/action-remark-lint@v5
         with:
-          fail_on_error: true
+          fail_level: ${{ inputs.fail-on-warnings && 'warning' || 'error' }}
           install_deps: false
           level: info
           reporter: github-pr-check


### PR DESCRIPTION
The 5.16.0 release of `reviewdog/action-remark-lint` deprecated the `fail_on_error` option in favour of a new `fail_level` option.

This commit switches the options out.

Refs:
* reviewdog/action-remark-lint#100
* reviewdog/reviewdog#1854