### PR TITLE
GH Actions: fix pin for setup-php

### DIFF
--- a/.github/workflows/reusable-phpstan.yml
+++ b/.github/workflows/reusable-phpstan.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Install PHP
         if: ${{ steps.has_config.outputs.files_exists == 'true' }}
-        uses: shivammathur/setup-php@ec406be512d7077f68eed36e63f4d91bc006edc4 # master
+        uses: shivammathur/setup-php@ec406be512d7077f68eed36e63f4d91bc006edc4 # 2.35.4
         with:
           php-version: ${{ inputs.phpVersion }}
           coverage: none


### PR DESCRIPTION
Follow up on #10

This should have the last released version as the version number, not "master".