### PR TITLE
Dependabot: change the cronjob scheduled time

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,7 @@ updates:
     directory: "/"
     schedule:
       interval: "cron"
-      cronjob: "10 22 5,20 * *" # At 22:10, every 5th and 20th day of the month.
+      cronjob: "45 23 4,19 * *" # At 23:45, every 4th and 19th day of the month.
     open-pull-requests-limit: 5
     commit-message:
       prefix: "GH Actions:"


### PR DESCRIPTION
In most cases, i.e. when Dependabot submits an update which involves the reusable workflow files, it is cause to do a new release.

As quite a number of other repos I manage _use_ the reusable workflows provided via this package, it feels like a good idea to trigger the Dependabot run for this repo a little earlier than the others to ensure that if the run for this repo would be reason for a new release, the _dependent_ packages will straight away update to that new release.