### PR TITLE
Reusable remark workflow: bump Node from 20 to 24

### DIFF
--- a/.github/workflows/reusable-remark.yml
+++ b/.github/workflows/reusable-remark.yml
@@ -30,7 +30,7 @@ jobs:
         if: ${{ steps.has_config.outputs.files_exists == 'true' }}
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
-          node-version: "20"
+          node-version: "24"
 
       # To make the command available on CLI, it needs to be installed globally.
       - name: Install Remark CLI globally


### PR DESCRIPTION
# Description

The `QA Markdown` job has been failing across the org with the following error:

```
TypeError: webidl.util.markAsUncloneable is not a function
```

`dead-or-alive@1.0.5`, pulled in transitively via `remark-lint-no-dead-urls`, bumped `undici` to `^8`. `undici@8` calls `markAsUncloneable`, a Node API only available from Node 22.10.0, while the workflow uses Node 20.

This PR bumps `node-version` to `"24"`, which fixes the failure and also moves CI off Node 20 (end of life).

Fixes the failing `QA Markdown` check on open PRs across the org. Examples: https://github.com/PHPCSStandards/PHPCSExtra/pull/439 and https://github.com/PHPCSStandards/PHP_CodeSniffer/pull/1438.

## How this was tested

I tested this change using [`act`](https://github.com/nektos/act) on my machine with the following temporary workflow file:

```yaml
name: Node version test
on: [workflow_dispatch]
jobs:
  call:
    uses: ./.github/workflows/reusable-remark.yml
```

```bash
gh act workflow_dispatch -W .github/workflows/node_version_test.yml
```

On `main` the job crashes with the `markAsUncloneable` error. On this branch it loads `.remarkrc` and lints successfully.
